### PR TITLE
fix(angular): Allow different boolean value accessor attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.swp
 .DS_Store
 .vscode
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -26,6 +26,49 @@ To make use of the AngularOutputPlugin first import it into your stencil.config.
 import { Config } from '@stencil/core';
 import { angularOutputTarget, ValueAccessorConfig } from '@stencil/angular-output-target';
 
+const EVENTS = {
+  'Select': 'ionSelect',
+  'Change': 'ionChange'
+};
+
+const ATTRS = {
+  'Checked': 'checked',
+  'Value': 'value'
+};
+
+const angularValueAccessorBindings: ValueAccessorConfig[] = [
+  {
+    elementSelectors: [ 'ion-checkbox', 'ion-toggle' ],
+    event: EVENTS.Change,
+    targetAttr: ATTRS.Checked,
+    type: 'boolean'
+  },
+  {
+    elementSelectors: [ 'ion-input[type=number]' ],
+    event: EVENTS.Change,
+    targetAttr: ATTRS.Value,
+    type: 'number'
+  },
+  {
+    elementSelectors: [ 'ion-radio' ],
+    event: EVENTS.Select,
+    targetAttr: ATTRS.Checked,
+    type: 'radio'
+  },
+  {
+    elementSelectors: [ 'ion-range', 'ion-select', 'ion-radio-group', 'ion-segment', 'ion-datetime' ],
+    event: EVENTS.Change,
+    targetAttr: ATTRS.Value,
+    type: 'select'
+  },
+  {
+    elementSelectors: ['ion-input:not([type=number])', 'ion-textarea', 'ion-searchbar'],
+    event: EVENTS.Change,
+    targetAttr: ATTRS.Value,
+    type: 'text'
+  },
+];
+
 export const config: Config = {
   namespace: 'demo',
   outputTargets: [

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "root",
   "private": true,
   "scripts": {
+    "postinstall": "lerna bootstrap",
     "build": "lerna run build"
   },
   "devDependencies": {
-    "@stencil/core": "^1.0.0-beta.5",
+    "@stencil/core": "^1.8.1",
     "lerna": "^3.13.1"
   }
 }

--- a/packages/angular-output-target/resources/control-value-accessors/boolean-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors/boolean-value-accessor.ts
@@ -22,6 +22,6 @@ export class BooleanValueAccessor extends ValueAccessor {
     super(el);
   }
   writeValue(value: any) {
-    this.el.nativeElement.<VALUE_ACCESSOR_SELECTORS> = this.lastValue = value == null ? false : value;
+    this.el.nativeElement.<VALUE_ACCESSOR_TARGETATTR> = this.lastValue = value == null ? false : value;
   }
 }

--- a/packages/angular-output-target/resources/control-value-accessors/boolean-value-accessor.ts
+++ b/packages/angular-output-target/resources/control-value-accessors/boolean-value-accessor.ts
@@ -22,6 +22,6 @@ export class BooleanValueAccessor extends ValueAccessor {
     super(el);
   }
   writeValue(value: any) {
-    this.el.nativeElement.checked = this.lastValue = value == null ? false : value;
+    this.el.nativeElement.<VALUE_ACCESSOR_SELECTORS> = this.lastValue = value == null ? false : value;
   }
 }

--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -62,22 +62,25 @@ async function writeValueAccessor(type: ValueAccessorTypes, valueAccessor: Value
 
   const finalText = srcFileContents
     .replace(VALUE_ACCESSOR_SELECTORS, valueAccessor.elementSelectors.join(', '))
-    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join('\n'));
+    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join(',\n'))
+    .replace(VALUE_ACCESSOR_TARGETATTR, valueAccessor.eventTargets[0][1])
 
   await compilerCtx.fs.writeFile(targetFilePath, finalText);
 }
 
 function copyResources(config: Config, resourcesFilesToCopy: string[], directory: string) {
   if (!config.sys || !config.sys.copy) {
-    throw new Error('stencil is not properly intialized at this step. Notify the developer');
+    throw new Error('stencil is not properly initialized at this step. Notify the developer');
   }
 
   return config.sys.copy(
     resourcesFilesToCopy.map(rf => ({
       src: path.join(__dirname, '../resources/control-value-accessors/', rf),
       dest: path.join(directory, rf),
+      keepDirStructure: true,
       warn: false
-    }))
+    })),
+    ''
   );
 }
 

--- a/packages/react-output-target/src/output-react.ts
+++ b/packages/react-output-target/src/output-react.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { OutputTargetReact } from './types';
-import { dashToPascalCase, readPackageJson, relativeImport, sortBy, normalizePath } from './utils';
+import { dashToPascalCase, normalizePath, readPackageJson, relativeImport, sortBy } from './utils';
 import { CompilerCtx, ComponentCompilerMeta, Config } from '@stencil/core/internal';
 
 export async function reactProxyOutput(
@@ -67,27 +67,22 @@ function createComponentDefinition(cmpMeta: ComponentCompilerMeta) {
   const tagNameAsPascal = dashToPascalCase(cmpMeta.tagName);
 
   return [
-    `export const ${tagNameAsPascal} = createReactComponent<${IMPORT_TYPES}.${tagNameAsPascal}, HTML${tagNameAsPascal}Element>('${
-      cmpMeta.tagName
-    }');`,
+    `export const ${tagNameAsPascal} = createReactComponent<${IMPORT_TYPES}.${tagNameAsPascal}, HTML${tagNameAsPascal}Element>('${cmpMeta.tagName}');`,
   ];
 }
 
 async function copyResources(config: Config, outputTarget: OutputTargetReact) {
   if (!config.sys || !config.sys.copy || !config.sys.glob) {
-    throw new Error('stencil is not properly intialized at this step. Notify the developer');
+    throw new Error('stencil is not properly initialized at this step. Notify the developer');
   }
   const srcDirectory = path.join(__dirname, '..', 'react-component-lib');
   const destDirectory = path.join(path.dirname(outputTarget.proxiesFile), 'react-component-lib');
-  const resourcesFilesToCopy = await config.sys.glob('**/*.*', { cwd: srcDirectory });
-
-  return config.sys.copy(
-    resourcesFilesToCopy.map(rf => ({
-      src: path.join(srcDirectory, '../react-component-lib/', rf),
-      dest: path.join(destDirectory, rf),
-      warn: false,
-    })),
-  );
+  return config.sys.copy([{
+    src: srcDirectory,
+    dest: destDirectory,
+    keepDirStructure: true,
+    warn: false,
+  }], '');
 }
 
 export const GENERATED_DTS = 'components.d.ts';


### PR DESCRIPTION
When stared the development of component like radio and checkbox, we used a "selected" attribute to represent the state of the radio/checkbox as boolean.

This PR allows a user to specify on which boolean property they want the nativeElement to be bind to. It is currently forced to the `checked` property.

Part of this PR:
- Added the small documentation related to #6.
- Updated react-output file to make sure both library compiles as expected (based on #15 PR work)