### PR TITLE
fix(react): pass data- and aria-attributes to React component (#25)

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -33,11 +33,17 @@ export const createReactComponent = <PropType, ElementType>(tagName: string) => 
       const { children, forwardedRef, style, className, ref, ...cProps } = this.props;
 
       const propsToPass = Object.keys(cProps).reduce((acc, name) => {
-        if (name.indexOf('on') === 0 && name[2] === name[2].toUpperCase()) {
+        const isEventProp = name.indexOf('on') === 0 && name[2] === name[2].toUpperCase();
+        const isDataProp = name.indexOf('data-') === 0;
+        const isAriaProp = name.indexOf('aria-') === 0;
+
+        if (isEventProp) {
           const eventName = name.substring(2).toLowerCase();
           if (isCoveredByReact(eventName)) {
             (acc as any)[name] = (cProps as any)[name];
           }
+        } else if (isDataProp || isAriaProp) {
+          (acc as any)[name] = (cProps as any)[name];
         }
         return acc;
       }, {});


### PR DESCRIPTION
Dear Ionic team!
I'm really amazed by you StencilJS and this `react-output-target` helper! But it seems that it misses some important bit. A generated component doesn't pass down `data-` and `aria-` attributes.

It would be great if you'll take a look on this PR.
Thank you 🙏 