### PR TITLE
Fixed deprecated warnings.

### DIFF
--- a/packages/react-output-target/react-component-lib/createComponent.tsx
+++ b/packages/react-output-target/react-component-lib/createComponent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDom from 'react-dom';
 
 import {
   attachEventProps,
@@ -16,8 +15,12 @@ interface IonicReactInternalProps<ElementType> extends React.HTMLAttributes<Elem
 export const createReactComponent = <PropType, ElementType>(tagName: string) => {
   const displayName = dashToPascalCase(tagName);
   const ReactComponent = class extends React.Component<IonicReactInternalProps<ElementType>> {
+    
+    private ref: React.RefObject<HTMLElement>;
+    
     constructor(props: IonicReactInternalProps<ElementType>) {
       super(props);
+      this.ref = React.createRef<HTMLElement>();
     }
 
     componentDidMount() {
@@ -25,7 +28,7 @@ export const createReactComponent = <PropType, ElementType>(tagName: string) => 
     }
 
     componentDidUpdate(prevProps: IonicReactInternalProps<ElementType>) {
-      const node = ReactDom.findDOMNode(this) as HTMLElement;
+      const node = this.ref.current;
       attachEventProps(node, this.props, prevProps);
     }
 
@@ -50,7 +53,7 @@ export const createReactComponent = <PropType, ElementType>(tagName: string) => 
 
       const newProps: any = {
         ...propsToPass,
-        ref: forwardedRef,
+        ref: this.ref,
         style,
         className,
       };


### PR DESCRIPTION
React has deprecated findDOMNode in StrictMode, in favour of Refs. @see https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage.